### PR TITLE
configure: Fix configure with CC="ccache gcc"

### DIFF
--- a/configure
+++ b/configure
@@ -648,9 +648,9 @@ for i in "$@"; do
 done
 
 if [[ $arch == x86_64* ]]; then
-	BUILD_CMD=("$CC" -o /dev/null -x c $CPPFLAGS $CFLAGS $LDFLAGS "-march=native")
+	BUILD_CMD=($CC -o /dev/null -x c $CPPFLAGS $CFLAGS $LDFLAGS "-march=native")
 else
-	BUILD_CMD=("$CC" -o /dev/null -x c $CPPFLAGS $CFLAGS $LDFLAGS)
+	BUILD_CMD=($CC -o /dev/null -x c $CPPFLAGS $CFLAGS $LDFLAGS)
 fi
 BUILD_CMD+=(-I/usr/local/include -L/usr/local/lib)
 


### PR DESCRIPTION
Buildroot (for example) passes CC="/workdir/build/host/bin/ccache /usr/bin/gcc" as an environment variable.
"$CC" (with quotes) thus fails because "No such file or directory".
$CC (without quotes) is already used in the script, so the quotes were removed where they caused the issue.
That *only* changes the detection of the dependencies. The makefile were not modified.

Another way to do things is possible, using `eval`, but that may cause issues with spaces in the $*FLAGS.